### PR TITLE
Use base directory for project paths and handle missing image

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -50,6 +50,10 @@ namespace BiosReleaseUI
                 try { logBackgroundImage = Drawing.Image.FromFile(imagePath); }
                 catch (Exception ex) { WinForms.MessageBox.Show("Background image input failure : " + ex.Message); }
             }
+            else
+            {
+                WinForms.MessageBox.Show("Background image not found. Using default background color.");
+            }
 
             InitializeUi();
 
@@ -195,6 +199,7 @@ namespace BiosReleaseUI
                 Dock = WinForms.DockStyle.Fill,
                 BackgroundImage = logBackgroundImage,
                 BackgroundImageLayout = WinForms.ImageLayout.Zoom,
+                BackColor = logBackgroundImage == null ? Drawing.Color.LightGray : Drawing.Color.Transparent,
                 Padding = new WinForms.Padding(10)
             };
 

--- a/Services/EnvironmentPaths.cs
+++ b/Services/EnvironmentPaths.cs
@@ -7,8 +7,7 @@ namespace BiosReleaseUI.Services
     {
         public static string GetProjectRoot()
         {
-            string? fullPath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory)?.Parent?.FullName;
-            return fullPath ?? string.Empty;
+            return AppDomain.CurrentDomain.BaseDirectory;
         }
 
         public static string GetPreDumpPath()
@@ -18,7 +17,7 @@ namespace BiosReleaseUI.Services
 
         public static string GetBackgroundImagePath()
         {
-            return Path.Combine(GetProjectRoot(), "BiosReleaseUI", "bg.jpg");
+            return Path.Combine(GetProjectRoot(), "bg.jpg");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Return `AppDomain.CurrentDomain.BaseDirectory` for project root and update background image path accordingly
- Alert when `bg.jpg` is missing and fall back to a default panel background color

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d54e5c80832ea199b0a0fa2b1734