### PR TITLE
Ensure bg.jpg is copied to build output

### DIFF
--- a/BiosReleaseUI.csproj
+++ b/BiosReleaseUI.csproj
@@ -9,4 +9,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="bg.jpg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- copy background image to output by adding content item to project file

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true`
- `ls bin/Debug/net9.0-windows`


------
https://chatgpt.com/codex/tasks/task_e_68a6dee26ac4832e8dc57ec2df6044ca