### PR TITLE
Check image file before applying ImageBrush

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -209,10 +209,15 @@ namespace BiosReleaseUI
             };
 
             string imagePath = EnvironmentPaths.GetBackgroundImagePath();
-            var grid = new WpfControls.Grid
+            var grid = new WpfControls.Grid();
+            if (File.Exists(imagePath))
             {
-                Background = new WpfMedia.ImageBrush(new WpfImaging.BitmapImage(new Uri(imagePath)))
-            };
+                grid.Background = new WpfMedia.ImageBrush(new WpfImaging.BitmapImage(new Uri(imagePath)));
+            }
+            else
+            {
+                grid.Background = WpfMedia.Brushes.LightGray;
+            }
             grid.Children.Add(wpfLogBox);
 
             logHost = new WinFormsIntegration.ElementHost


### PR DESCRIPTION
## Summary
- Avoid ImageBrush creation when the background image path is missing, using a light gray fallback instead.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0. Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6def5bb38832e8ba610b958209b34