### PR TITLE
Ensure log panel fills remaining space

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -267,9 +267,9 @@ namespace BiosReleaseUI
 
             logBackgroundPanel.Controls.Add(logLayout);
 
-            Controls.Add(logBackgroundPanel);
-            Controls.Add(controlPanel);
             Controls.Add(statusPanel);
+            Controls.Add(controlPanel);
+            Controls.Add(logBackgroundPanel);
         }
 
         private WinForms.Button CreateStyledButton(string text, Drawing.Color backColor, Drawing.Color foreColor, bool bold = false, int fontSize = 11)


### PR DESCRIPTION
## Summary
- add `statusPanel` and `controlPanel` before `logBackgroundPanel` so the log area fills the remaining space

## Testing
- `~/dotnet/dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a6def7d5a0832e967373f3f71ebfd0