### PR TITLE
Adjust layout for DPI scaling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -78,6 +78,7 @@ namespace BiosReleaseUI
             Text = "BIOS Release Tool";
             Width = 1140;
             Height = 1380;
+            MinimumSize = new Drawing.Size(1140, 1380);
             Font = new Drawing.Font("Segoe UI", 10);
             AutoScaleMode = WinForms.AutoScaleMode.Dpi;
             BackColor = Drawing.Color.White;
@@ -118,10 +119,10 @@ namespace BiosReleaseUI
                 AutoSize = true,
                 AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
             };
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Percent, 25F));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Percent, 25F));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Percent, 25F));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Percent, 25F));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
 
             checkFilesButton = CreateStyledButton("① Check Material Files", Drawing.Color.FromArgb(220, 230, 250), Drawing.Color.DarkBlue, true, stepFontSize);
             runMainCodeButton = CreateStyledButton("③ Execute Make_csv_file.bat", Drawing.Color.FromArgb(230, 250, 230), Drawing.Color.DarkGreen, true, stepFontSize);


### PR DESCRIPTION
## Summary
- enforce AutoSize row styles for control panel
- lock form minimum size to maintain layout on high-DPI displays

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6defa2c10832eb44ba9ef8e287280