### PR TITLE
Ensure log panel docks behind top panels

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -273,9 +273,10 @@ namespace BiosReleaseUI
 
             logBackgroundPanel.Controls.Add(logLayout);
 
-            Controls.Add(statusPanel);
-            Controls.Add(controlPanel);
+            // Ensure the log panel is at the back so top panels occupy the full width.
             Controls.Add(logBackgroundPanel);
+            Controls.Add(controlPanel);
+            Controls.Add(statusPanel);
         }
 
         private WinForms.Button CreateStyledButton(string text, Drawing.Color backColor, Drawing.Color foreColor, bool bold = false, int fontSize = 11)


### PR DESCRIPTION
## Summary
- Place log area panel in controls collection before top panels so it stays in the background

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet BiosReleaseUI.dll` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e1904d18832e89802e794cc5eb2d