### PR TITLE
Use screen working area for dynamic form size

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -79,9 +79,10 @@ namespace BiosReleaseUI
             int stepFontSize = 17;
 
             Text = "BIOS Release Tool";
-            Width = 1140;
-            Height = 1380;
-            MinimumSize = new Drawing.Size(1140, 1380);
+            // Dynamically size to fit the available screen area
+            var workingArea = WinForms.Screen.PrimaryScreen.WorkingArea;
+            Width = workingArea.Width;
+            Height = workingArea.Height;
             Font = new Drawing.Font("Segoe UI", 10);
             AutoScaleMode = WinForms.AutoScaleMode.Dpi;
             BackColor = Drawing.Color.White;


### PR DESCRIPTION
## Summary
- Dynamically size the main window based on the primary screen's available working area
- Remove fixed minimum form size to better support varying resolutions

## Testing
- ⚠️ `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- ✅ `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a7e8dec054832eae5f2109bfea4c7f