### PR TITLE
Prevent log controls from being obscured

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -286,6 +286,9 @@ namespace BiosReleaseUI
             buttonPanel.Controls.Add(clearLogButton);
             buttonPanel.Controls.Add(saveLogButton);
             logLayout.Controls.Add(buttonPanel, 0, 1);
+            // Ensure the button panel remains visible above the log host
+            logHost.SendToBack();
+            buttonPanel.BringToFront();
 
             logBackgroundPanel.Controls.Add(logLayout);
 


### PR DESCRIPTION
## Summary
- Ensure Save Log and Clear Log buttons stay accessible by sending the log host to the back and bringing the button panel to the front

## Testing
- `dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a7e8f48698832ea95a7ea28cc0481c