### PR TITLE
Add Pre_Dump folder check in file validation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -394,6 +394,17 @@ namespace BiosReleaseUI
 
         private void CheckFilesButton_Click(object? sender, EventArgs e)
         {
+            if (!Directory.Exists(preDumpPath))
+            {
+                WinForms.MessageBox.Show(
+                    "Pre_Dump folder not found. Please create Pre_Dump in program directory.",
+                    "Pre_Dump Missing",
+                    WinForms.MessageBoxButtons.OK,
+                    WinForms.MessageBoxIcon.Warning);
+                statusLabel.Text = "Status: ⚠ Pre_Dump folder not found";
+                return;
+            }
+
             logService.Clear();
             var result = materialChecker.CheckMaterials(preDumpPath);
             foreach (var msg in result.Messages)


### PR DESCRIPTION
## Summary
- guard against missing Pre_Dump folder before checking files
- notify user and update status when Pre_Dump directory is absent

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e8fd4898832ea7ae08834187ef65