### PR TITLE
Use fixed dimensions for main window

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -79,12 +79,12 @@ namespace BiosReleaseUI
             int stepFontSize = 17;
 
             Text = "BIOS Release Tool";
-            // Dynamically size to fit the available screen area
-            var workingArea = WinForms.Screen.PrimaryScreen.WorkingArea;
-            Width = workingArea.Width;
-            Height = workingArea.Height;
+            // Use a fixed size for consistent layout across displays
+            Width = 1140;
+            Height = 1380;
+            StartPosition = WinForms.FormStartPosition.CenterScreen;
             Font = new Drawing.Font("Segoe UI", 10);
-            AutoScaleMode = WinForms.AutoScaleMode.Dpi;
+            AutoScaleMode = WinForms.AutoScaleMode.None;
             BackColor = Drawing.Color.White;
 
             var statusPanel = new WinForms.Panel


### PR DESCRIPTION
## Summary
- use explicit 1140x1380 size instead of dynamic working-area bounds
- center the main window and disable automatic DPI scaling to keep dimensions constant

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8129211b0832e96e21552826a2817