### PR TITLE
Add fixed layout dimensions for control panel

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -77,6 +77,8 @@ namespace BiosReleaseUI
         private void InitializeUi()
         {
             int stepFontSize = 17;
+            const int stepBtnHeight = 85;
+            const int groupBoxHeight = 170;
 
             Text = "BIOS Release Tool";
             // Dynamically size to fit the available screen area
@@ -120,20 +122,19 @@ namespace BiosReleaseUI
                 RowCount = 4,
                 ColumnCount = 1,
                 Padding = new WinForms.Padding(10),
-                AutoSize = true,
-                AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
+                AutoSize = false
             };
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
-            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.AutoSize));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, stepBtnHeight));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, groupBoxHeight));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, stepBtnHeight));
+            controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, stepBtnHeight));
 
-            checkFilesButton = CreateStyledButton("① Check Material Files", Drawing.Color.FromArgb(220, 230, 250), Drawing.Color.DarkBlue, true, stepFontSize);
-            runMainCodeButton = CreateStyledButton("③ Execute Make_csv_file.bat", Drawing.Color.FromArgb(230, 250, 230), Drawing.Color.DarkGreen, true, stepFontSize);
+            checkFilesButton = CreateStyledButton("① Check Material Files", Drawing.Color.FromArgb(220, 230, 250), Drawing.Color.DarkBlue, true, stepFontSize, stepBtnHeight);
+            runMainCodeButton = CreateStyledButton("③ Execute Make_csv_file.bat", Drawing.Color.FromArgb(230, 250, 230), Drawing.Color.DarkGreen, true, stepFontSize, stepBtnHeight);
             runButtonDefaultBackColor = runMainCodeButton.BackColor;
             runButtonOverlayLabel = CreateOverlayLabel();
             runMainCodeButton.Controls.Add(runButtonOverlayLabel);
-            openReleaseNoteButton = CreateStyledButton("④ Open BIOS_RELEASE_NOTE.xlsm", Drawing.Color.FromArgb(250, 240, 200), Drawing.Color.SaddleBrown, true, stepFontSize);
+            openReleaseNoteButton = CreateStyledButton("④ Open BIOS_RELEASE_NOTE.xlsm", Drawing.Color.FromArgb(250, 240, 200), Drawing.Color.SaddleBrown, true, stepFontSize, stepBtnHeight);
 
             runMainCodeButton.Enabled = false;
             openReleaseNoteButton.Enabled = false;
@@ -145,7 +146,8 @@ namespace BiosReleaseUI
                 Text = "② Platform Selection",
                 Dock = WinForms.DockStyle.Fill,
                 Padding = new WinForms.Padding(10),
-                Font = new Drawing.Font("Segoe UI", 12, Drawing.FontStyle.Bold)
+                Font = new Drawing.Font("Segoe UI", 12, Drawing.FontStyle.Bold),
+                Height = groupBoxHeight
             };
             var platformLayout = new WinForms.TableLayoutPanel
             {
@@ -299,12 +301,13 @@ namespace BiosReleaseUI
             Controls.Add(statusPanel);
         }
 
-        private WinForms.Button CreateStyledButton(string text, Drawing.Color backColor, Drawing.Color foreColor, bool bold = false, int fontSize = 11)
+        private WinForms.Button CreateStyledButton(string text, Drawing.Color backColor, Drawing.Color foreColor, bool bold = false, int fontSize = 11, int height = 0)
         {
             var button = new WinForms.Button
             {
                 Text = text,
-                Dock = WinForms.DockStyle.Fill,
+                Dock = WinForms.DockStyle.Top,
+                Height = height,
                 FlatStyle = WinForms.FlatStyle.Flat,
                 BackColor = backColor,
                 ForeColor = foreColor,


### PR DESCRIPTION
## Summary
- Define constants for step button and group box heights
- Use absolute row styles to stabilize control panel layout
- Dock step buttons at top with fixed heights and lock platform selection group box size

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8129594d0832e89dc62a0d89bb994