### PR TITLE
fix: prevent window resizing and status panel growth

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -81,19 +81,26 @@ namespace BiosReleaseUI
             const int groupBoxHeight = 170;
 
             Text = "BIOS Release Tool";
-            // Use a fixed size for consistent layout across displays
+            // Use a fixed, non-resizable window to prevent layout scaling issues
             Width = 1140;
             Height = 1380;
             StartPosition = WinForms.FormStartPosition.CenterScreen;
             Font = new Drawing.Font("Segoe UI", 10);
             AutoScaleMode = WinForms.AutoScaleMode.None;
             BackColor = Drawing.Color.White;
+            FormBorderStyle = WinForms.FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
+            MinimumSize = new Drawing.Size(Width, Height);
+            MaximumSize = new Drawing.Size(Width, Height);
 
             var statusPanel = new WinForms.Panel
             {
                 Dock = WinForms.DockStyle.Top,
                 Height = 50,
-                BackColor = Drawing.Color.LightSteelBlue
+                BackColor = Drawing.Color.LightSteelBlue,
+                AutoSize = false,
+                MinimumSize = new Drawing.Size(0, 50),
+                MaximumSize = new Drawing.Size(int.MaxValue, 50)
             };
             statusLabel = new WinForms.Label
             {


### PR DESCRIPTION
## Summary
- lock window size and disable maximize to keep layout stable
- constrain status panel height to stop it from expanding during resize

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8000f1df0832eadd1e8fcce8c3085