### PR TITLE
Refine layout margins for control and status panels

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -101,7 +101,8 @@ namespace BiosReleaseUI
                 BackColor = Drawing.Color.LightSteelBlue,
                 AutoSize = false,
                 MinimumSize = new Drawing.Size(0, statusPanelHeight),
-                MaximumSize = new Drawing.Size(int.MaxValue, statusPanelHeight)
+                MaximumSize = new Drawing.Size(int.MaxValue, statusPanelHeight),
+                Margin = new WinForms.Padding(0)
             };
             statusLabel = new WinForms.Label
             {
@@ -129,9 +130,10 @@ namespace BiosReleaseUI
                 Dock = WinForms.DockStyle.Top,
                 RowCount = 4,
                 ColumnCount = 1,
-                Padding = new WinForms.Padding(10),
+                Padding = new WinForms.Padding(10, 0, 10, 10),
                 AutoSize = false,
-                Height = controlPanelHeight
+                Height = controlPanelHeight,
+                Margin = new WinForms.Padding(0)
             };
             controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, stepBtnHeight));
             controlPanel.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Absolute, groupBoxHeight));


### PR DESCRIPTION
## Summary
- remove default margins from status and control panels to tighten layout
- adjust control panel padding to keep horizontal spacing while eliminating top gap

## Testing
- `dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a832f873dc832eb7eb9e630ea9bc36