### PR TITLE
Ensure log button panel resizes and docks to bottom

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -290,10 +290,11 @@ namespace BiosReleaseUI
 
             var buttonPanel = new WinForms.FlowLayoutPanel
             {
-                Dock = WinForms.DockStyle.Right,
+                Dock = WinForms.DockStyle.Bottom,
                 FlowDirection = WinForms.FlowDirection.RightToLeft,
                 Padding = new WinForms.Padding(5, 12, 5, 12),
-                AutoSize = true
+                AutoSize = true,
+                AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
             };
             buttonPanel.Controls.Add(clearLogButton);
             buttonPanel.Controls.Add(saveLogButton);


### PR DESCRIPTION
## Summary
- Keep log layout's second row set to `SizeType.AutoSize` for flexible button row sizing
- Dock log action buttons panel to the bottom and enable `GrowAndShrink` autosizing

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a83333c5c0832ebeecdbcef372e31e