### PR TITLE
Fix panel z-order for top controls

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -304,10 +304,13 @@ namespace BiosReleaseUI
 
             logBackgroundPanel.Controls.Add(logLayout);
 
-            // Ensure the log panel is at the back so top panels occupy the full width.
-            Controls.Add(logBackgroundPanel);
-            Controls.Add(controlPanel);
+            // Add panels such that the log panel is at the back, allowing top panels to occupy the full width.
             Controls.Add(statusPanel);
+            Controls.Add(controlPanel);
+            Controls.Add(logBackgroundPanel);
+
+            controlPanel.BringToFront();
+            statusPanel.BringToFront();
 
             Resize += (s, e) =>
             {


### PR DESCRIPTION
## Summary
- ensure control and status panels stay above log panel by adjusting add order
- explicitly bring control and status panels to front after UI initialization

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true`
- `~/.dotnet/dotnet run -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a833399930832e83fe58ecf0f91e4f